### PR TITLE
【追加実装】エラーメッセージの日本語対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,5 @@ gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 
 gem 'payjp'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
+    rails-i18n (7.0.7)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.6.1)
       actionpack (= 6.0.6.1)
       activesupport (= 6.0.6.1)
@@ -331,6 +334,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,9 +16,9 @@ class Item < ApplicationRecord
   belongs_to :prefecture
   belongs_to :scheduled_delivery
 
-  validates :category_id, numericality: { other_than: 1, message: "can't be blank" }
-  validates :sales_status_id, numericality: { other_than: 1, message: "can't be blank" }
-  validates :shipping_fee_status_id, numericality: { other_than: 1, message: "can't be blank" }
-  validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
-  validates :scheduled_delivery_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :category_id, numericality: { other_than: 1, message: "を選んでください"}
+  validates :sales_status_id, numericality: { other_than: 1, message: "を選んでください"}
+  validates :shipping_fee_status_id, numericality: { other_than: 1, message: "を選んでください"}
+  validates :prefecture_id, numericality: { other_than: 1, message: "を選んでください"}
+  validates :scheduled_delivery_id, numericality: { other_than: 1, message: "を選んでください"}
 end

--- a/app/models/order_shipping.rb
+++ b/app/models/order_shipping.rb
@@ -3,15 +3,15 @@ class OrderShipping
   attr_accessor :postal_code, :prefecture_id, :city, :addresses, :building, :phone_number, :item_id, :user_id, :token
 
   with_options presence: true do
-    validates :postal_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
+    validates :postal_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'はすべて半角で、3桁と4桁をハイフン(-)で区切って入力してください' }
     validates :city
     validates :addresses
-    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: 'is invalid. 10 or 11 digits long. Exclude hyphen(-)' }
+    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: 'は半角数字で、ハイフン(-)無しで10桁または11桁で入力してください' }
     validates :user_id
     validates :item_id
     validates :token
   end
-  validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :prefecture_id, numericality: { other_than: 1, message: "を選んでください" }
 
   def save
     order = Order.create(item_id: item_id, user_id: user_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,18 +11,18 @@ class User < ApplicationRecord
   validates :first_name_kana, presence: true
   validates :birth_date, presence: true
 
-  with_options presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'には全角文字を使用してください' } do
+  with_options presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'は全角文字を使用してください' } do
     validates :first_name
     validates :last_name
   end
 
-  with_options presence: true, format: { with: /\A[ァ-ヶー－]+\z/, message: 'には全角カナを使用してください' } do
+  with_options presence: true, format: { with: /\A[ァ-ヶー－]+\z/, message: 'は全角カナを使用してください' } do
     validates :first_name_kana
     validates :last_name_kana
   end
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
-  validates_format_of :password, with: PASSWORD_REGEX, message: 'には半角の英字と数字の両方を含めて設定してください'
+  validates_format_of :password, with: PASSWORD_REGEX, message: 'は半角の英字と数字の両方を含めて、6文字以上で設定してください'
 
   has_many :items
   has_many :orders

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Furima39312
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,30 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        last_name: お名前の名字
+        first_name: お名前の名前
+        last_name_kana: お名前カナの名字
+        first_name_kana: お名前カナの名前
+        birth_date: 生年月日
+      item:
+        item_name: 商品名
+        image: 画像
+        info: 商品の説明
+        price: 販売価格
+        category_id: カテゴリー
+        sales_status_id: 商品の状態
+        shipping_fee_status_id: 配送料の負担
+        prefecture_id: 発送元の地域
+        scheduled_delivery_id: 発送までの日数
+  activemodel:
+    attributes:
+      order_shipping:
+        postal_code: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        addresses: 番地
+        building: 建物名
+        phone_number: 電話番号
+        token: クレジットカード情報

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,79 +16,79 @@ RSpec.describe Item, type: :model do
       it '商品画像が空では保存できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("画像を入力してください")
       end
 
       it '商品名が空では保存できない' do
         @item.item_name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item name can't be blank")
+        expect(@item.errors.full_messages).to include("商品名を入力してください")
       end
 
       it '商品の説明が空では保存できない' do
         @item.info = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Info can't be blank")
+        expect(@item.errors.full_messages).to include("商品の説明を入力してください")
       end
 
       it 'カテゴリーの情報が初期値では保存できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category can't be blank")
+        expect(@item.errors.full_messages).to include("カテゴリーを選んでください")
       end
 
       it '商品の状態の情報が初期値では保存できない' do
         @item.sales_status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Sales status can't be blank")
+        expect(@item.errors.full_messages).to include("商品の状態を選んでください")
       end
 
       it '配送料の負担の情報が初期値では保存できない' do
         @item.shipping_fee_status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee status can't be blank")
+        expect(@item.errors.full_messages).to include("配送料の負担を選んでください")
       end
 
       it '発送元の地域の情報が初期値では保存できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@item.errors.full_messages).to include("発送元の地域を選んでください")
       end
 
       it '発送までの日数の情報が初期値では保存できない' do
         @item.scheduled_delivery_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Scheduled delivery can't be blank")
+        expect(@item.errors.full_messages).to include("発送までの日数を選んでください")
       end
 
       it '価格の情報が空では保存できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
+        expect(@item.errors.full_messages).to include("販売価格を入力してください")
       end
 
       it '価格が299円以下では保存できない' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price は半角数字で、￥300〜￥9,999,999の間で設定してください')
+        expect(@item.errors.full_messages).to include('販売価格は半角数字で、￥300〜￥9,999,999の間で設定してください')
       end
 
       it '価格が10000000円以上では保存できない' do
         @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price は半角数字で、￥300〜￥9,999,999の間で設定してください')
+        expect(@item.errors.full_messages).to include('販売価格は半角数字で、￥300〜￥9,999,999の間で設定してください')
       end
 
       it '価格が全角数字では保存できない' do
         @item.price = '３００'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price は半角数字で、￥300〜￥9,999,999の間で設定してください')
+        expect(@item.errors.full_messages).to include('販売価格は半角数字で、￥300〜￥9,999,999の間で設定してください')
       end
 
       it 'userが紐付いていないと保存できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include('User must exist')
+        expect(@item.errors.full_messages).to include('Userを入力してください')
       end
     end
   end

--- a/spec/models/order_shipping_spec.rb
+++ b/spec/models/order_shipping_spec.rb
@@ -23,79 +23,79 @@ RSpec.describe OrderShipping, type: :model do
       it '郵便番号が空では保存できないこと' do
         @order_shipping.postal_code = ''
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Postal code can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("郵便番号を入力してください")
       end
 
       it '郵便番号が「3桁+ハイフン+4桁」の半角文字列でないと保存できないこと' do
         @order_shipping.postal_code = '1234567'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Postal code is invalid. Include hyphen(-)')
+        expect(@order_shipping.errors.full_messages).to include('郵便番号はすべて半角で、3桁と4桁をハイフン(-)で区切って入力してください')
       end
 
       it '都道府県の情報が初期値では保存できないこと' do
         @order_shipping.prefecture_id = 1
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@order_shipping.errors.full_messages).to include('都道府県を選んでください')
       end
 
       it '市区町村が空では保存できないこと' do
         @order_shipping.city = ''
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("City can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("市区町村を入力してください")
       end
 
       it '番地が空では保存できないこと' do
         @order_shipping.addresses = ''
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Addresses can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("番地を入力してください")
       end
 
       it '電話番号が空では保存できないこと' do
         @order_shipping.phone_number = ''
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Phone number can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("電話番号を入力してください")
       end
 
       it '電話番号が10桁以上11桁以内の半角数値でなければ保存できないこと' do
         @order_shipping.phone_number = '090-1234-5678'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. 10 or 11 digits long. Exclude hyphen(-)')
+        expect(@order_shipping.errors.full_messages).to include('電話番号は半角数字で、ハイフン(-)無しで10桁または11桁で入力してください')
       end
 
       it '電話番号が9桁以下では保存できないこと' do
         @order_shipping.phone_number = '090123456'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. 10 or 11 digits long. Exclude hyphen(-)')
+        expect(@order_shipping.errors.full_messages).to include('電話番号は半角数字で、ハイフン(-)無しで10桁または11桁で入力してください')
       end
 
       it '電話番号が12桁以上では保存できないこと' do
         @order_shipping.phone_number = '090123456789'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. 10 or 11 digits long. Exclude hyphen(-)')
+        expect(@order_shipping.errors.full_messages).to include('電話番号は半角数字で、ハイフン(-)無しで10桁または11桁で入力してください')
       end
 
       it '電話番号に半角数字以外が含まれている場合は保存できないこと' do
         @order_shipping.phone_number = '０９０１２３４５６７８'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid. 10 or 11 digits long. Exclude hyphen(-)')
+        expect(@order_shipping.errors.full_messages).to include('電話番号は半角数字で、ハイフン(-)無しで10桁または11桁で入力してください')
       end
 
       it 'userが紐づいていない場合は保存できないこと' do
         @order_shipping.user_id = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("User can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("Userを入力してください")
       end
 
       it 'itemが紐づいていない場合は保存できないこと' do
         @order_shipping.item_id = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Item can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("Itemを入力してください")
       end
 
       it 'tokenが空では登録できないこと' do
         @order_shipping.token = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Token can't be blank")
+        expect(@order_shipping.errors.full_messages).to include('クレジットカード情報を入力してください')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,129 +16,129 @@ RSpec.describe User, type: :model do
       it 'nicknameが空では登録できない' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
       it 'emailが空では登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください")
       end
       it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
       it 'passwordが5文字以下では登録できない' do
         @user.password = 'abc12'
         @user.password_confirmation = 'abc12'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        expect(@user.errors.full_messages).to include('パスワードは6文字以上で入力してください')
       end
 
       it 'passwordとpassword_confirmationが不一致では登録できない' do
         @user.password_confirmation = 'abc1234'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
 
       it 'passwordが英数字でないと登録できない' do
         @user.password = 'あabc12'
         @user.password_confirmation = 'あabc12'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password には半角の英字と数字の両方を含めて設定してください')
+        expect(@user.errors.full_messages).to include('パスワードは半角の英字と数字の両方を含めて、6文字以上で設定してください')
       end
 
       it 'passwordが半角数字でないと登録できない' do
         @user.password = 'abc１２３'
         @user.password_confirmation = 'abc１２３'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password には半角の英字と数字の両方を含めて設定してください')
+        expect(@user.errors.full_messages).to include('パスワードは半角の英字と数字の両方を含めて、6文字以上で設定してください')
       end
 
       it 'passwordが半角英字でないと登録できない' do
         @user.password = 'ＡＢＣ123'
         @user.password_confirmation = 'ＡＢＣ123'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password には半角の英字と数字の両方を含めて設定してください')
+        expect(@user.errors.full_messages).to include('パスワードは半角の英字と数字の両方を含めて、6文字以上で設定してください')
       end
 
       it 'passwordが半角数字がないと登録できない' do
         @user.password = 'abcdef'
         @user.password_confirmation = 'abcdef'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password には半角の英字と数字の両方を含めて設定してください')
+        expect(@user.errors.full_messages).to include('パスワードは半角の英字と数字の両方を含めて、6文字以上で設定してください')
       end
 
       it 'passwordが半角数字のみの場合登録できない' do
         @user.password = '123456'
         @user.password_confirmation = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password には半角の英字と数字の両方を含めて設定してください')
+        expect(@user.errors.full_messages).to include('パスワードは半角の英字と数字の両方を含めて、6文字以上で設定してください')
       end
 
       it '重複したemailが存在する場合は登録できない' do
         @user.save
         another_user = FactoryBot.build(:user, email: @user.email)
         another_user.valid?
-        expect(another_user.errors.full_messages).to include('Email has already been taken')
+        expect(another_user.errors.full_messages).to include('Eメールはすでに存在します')
       end
       it 'emailは@を含まないと登録できない' do
         @user.email = 'testmail'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors.full_messages).to include('Eメールは不正な値です')
       end
       it '名字が空では登録できない' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name can't be blank")
+        expect(@user.errors.full_messages).to include('お名前の名字を入力してください')
       end
 
       it '名前が空では登録できない' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name can't be blank")
+        expect(@user.errors.full_messages).to include('お名前の名前を入力してください')
       end
 
       it '名字が全角（漢字・ひらがな・カタカナ）でないと登録できない' do
         @user.last_name = 'yamada'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name には全角文字を使用してください')
+        expect(@user.errors.full_messages).to include('お名前の名字は全角文字を使用してください')
       end
 
       it '名前が全角（漢字・ひらがな・カタカナ）でないと登録できない' do
         @user.first_name = 'rikutaro'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name には全角文字を使用してください')
+        expect(@user.errors.full_messages).to include('お名前の名前は全角文字を使用してください')
       end
 
       it '名字カナが空では登録できない' do
         @user.last_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana can't be blank")
+        expect(@user.errors.full_messages).to include("お名前カナの名字を入力してください")
       end
 
       it '名字カナが全角（カタカナ）でないと登録できない' do
         @user.last_name_kana = 'やまだ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana には全角カナを使用してください')
+        expect(@user.errors.full_messages).to include('お名前カナの名字は全角カナを使用してください')
       end
 
       it '名前カナが空では登録できない' do
         @user.first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana can't be blank")
+        expect(@user.errors.full_messages).to include('お名前カナの名前を入力してください')
       end
 
       it '名前カナが全角（カタカナ）でないと登録できない' do
         @user.first_name_kana = 'りくたろう'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana には全角カナを使用してください')
+        expect(@user.errors.full_messages).to include('お名前カナの名前は全角カナを使用してください')
       end
 
       it '生年月日が空では登録できない' do
         @user.birth_date = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birth date can't be blank")
+        expect(@user.errors.full_messages).to include('生年月日を入力してください')
       end
     end
   end


### PR DESCRIPTION
# What
エラーメッセージの日本語対応の実装

# Why
会員登録・購入登録・商品登録・編集時のエラー発生時のエラーメッセージを日本語化